### PR TITLE
Feature: Development Only Scripts template

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,63 @@ export default defineConfig((configEnv) => ({
 
 ### 4. You can now include Vite assets for development / production in your Fusion files:
 
+Let the package include everything for you, including [vite development scripts](https://vitejs.dev/guide/backend-integration):
+
+```fusion
+prototype(Customer.Base:Document.DefaultPage) < prototype(Neos.Neos:Page) {
+    head {
+        javascript.base = Networkteam.Neos.Vite:Head.Assets {
+            header = Networkteam.Neos.Vite:Asset {
+                entry = 'Resources/Private/Javascript/header.js'
+            }
+        }
+    }
+
+    bodyAssets = Networkteam.Neos.Vite:Body.Assets {
+        footer = Networkteam.Neos.Vite:Asset {
+          entry = 'Resources/Private/Javascript/footer.js'
+        }
+
+        // Include development scripts needed by Vite, for example:
+        developmentOnlyScripts {
+            // here you have access to the Vite server URL via context variable `viteUrl`
+            pluginName = ${'<script type="module" src="' + viteUrl + '@vite-plugin/client"></script>'}
+        }
+        @position = 'before closingBodyTag'
+    }
+}
+```
+
+Or, include everything manually using:
+
 ```fusion
 header = Networkteam.Neos.Vite:Asset {
     entry = 'Resources/Private/Javascript/header.js'
+}
+
+developmentOnlyScripts = Networkteam.Neos.Vite:Helper.DevelopmentOnlyScripts {
+    @context.viteUrl = ${Configuration.setting('Networkteam.Neos.Vite.server._default.url')}
+    pluginName = '<script type="module" src="' + viteUrl + '@vite-plugin/client"></script>'
+}
+```
+
+You can also use development-only scripts as Condition with Prototype `Networkteam.Neos.Vite:Helper.IsDevelopmentOnly`:
+
+```fusion
+prototype(Customer.Base:Helper.SpritemapBaseUrl) < prototype(Neos.Fusion:Case) {
+    inDevelopmentMode {
+        condition = Networkteam.Neos.Vite:Helper.IsDevelopmentOnly
+        renderer = '#icon-'
+    }
+    default {
+        condition = ${false}
+        renderer = Neos.Fusion:Value {
+            @context.spritemap = Networkteam.Neos.Vite:AssetUrl {
+                entry = 'spritemap.svg'
+            }
+            value = ${spritemap + '#icon-'}
+        }
+    }
 }
 ```
 

--- a/Resources/Private/Fusion/Body/Assets.fusion
+++ b/Resources/Private/Fusion/Body/Assets.fusion
@@ -1,0 +1,6 @@
+prototype(Networkteam.Neos.Vite:Body.Assets) < prototype(Neos.Fusion:Join) {
+    developmentOnlyScripts = Networkteam.Neos.Vite:Helper.DevelopmentOnlyScripts {
+        @context.viteUrl = ${Configuration.setting('Networkteam.Neos.Vite.server._default.url')}
+        // insert the vite client scripts
+    }
+}

--- a/Resources/Private/Fusion/Head/Assets.fusion
+++ b/Resources/Private/Fusion/Head/Assets.fusion
@@ -1,0 +1,7 @@
+prototype(Networkteam.Neos.Vite:Head.Assets) < prototype(Neos.Fusion:Join) {
+    developmentOnlyScripts = Networkteam.Neos.Vite:Helper.DevelopmentOnlyScripts {
+        @context.viteUrl = ${Configuration.setting('Networkteam.Neos.Vite.server._default.url')}
+        // Inject the react-refresh runtime into the page see: https://vitejs.dev/guide/backend-integration
+        reactRefresh = ${"<script type='module'>import RefreshRuntime from '" + viteUrl + "@react-refresh';RefreshRuntime.injectIntoGlobalHook(window);window.$RefreshReg$ = () => {};window.$RefreshSig$ = () => (type) => type;window.__vite_plugin_react_preamble_installed__ = true</script>"}
+    }
+}

--- a/Resources/Private/Fusion/Helper/DevelopmentOnly.fusion
+++ b/Resources/Private/Fusion/Helper/DevelopmentOnly.fusion
@@ -1,0 +1,31 @@
+/**
+  * Usage:
+  * developmentOnlyScripts = Viebrockhaus.Base:Helper.DevelopmentOnlyScripts {
+  *     @context.viteUrl = ${Configuration.setting('Networkteam.Neos.Vite.server._default.url')}
+  *     0 = ${'<script type="module" src="' + viteUrl + '@vite-plugin-svg-spritemap/client"></script>'}
+  * }
+  *
+  */
+
+prototype(Networkteam.Neos.Vite:Helper.DevelopmentOnlyScripts) < prototype(Neos.Fusion:Join) {
+    @context {
+        flowContext = ${Configuration.setting('Neos.Flow.core.context')}
+    }
+    @if.isDevelopmentContext = ${String.indexOf(flowContext, 'Development') >= 0}
+}
+
+prototype(Networkteam.Neos.Vite:Helper.IsDevelopmentOnly) < prototype(Neos.Fusion:Case) {
+    @context {
+        flowContext = ${Configuration.setting('Neos.Flow.core.context')}
+    }
+
+    inDevelopment {
+        condition = ${String.indexOf(flowContext, 'Development') >= 0}
+        renderer = ${true}
+    }
+
+    default {
+        condition = ${true}
+        renderer = ${false}
+    }
+}


### PR DESCRIPTION
Feature:

 - Added `Networkteam.Neos.Vite:Helper.DevelopmentOnlyScripts` for including scripts in development context only.
 - Added `Networkteam.Neos.Vite:Helper.IsDevelopmentOnly` as a boolean check if inside development context.
 - Added `Networkteam.Neos.Vite:Head.Assets` for head-scripts, including react-refresh-runtime, which is needed for any react-base development.
   - this is a philosophical question whether we want to auto include it here...? I'd say there is nothing wrong with it, as most of the time users of this package use react; it is only included in dev-context.
 - Added `Networkteam.Neos.Vite:Body.Assets` for wrapping projects body scripts.
 
 
 I'd like some feedback whether this is a valid approach or if one rather wants to leave more configuration to the customer project.
