### PR TITLE
Fix modulepreload tag

### DIFF
--- a/Classes/AssetIncludesBuilder.php
+++ b/Classes/AssetIncludesBuilder.php
@@ -155,7 +155,7 @@ class AssetIncludesBuilder
         foreach ($imports as $import) {
             $manifestEntry = $manifestJson[$import];
             if (isset($manifestEntry['file'])) {
-                $includes[] = '<script type="modulepreload" src="' . htmlspecialchars($this->buildPublicResourceUrl($manifestEntry['file']), ENT_QUOTES, 'UTF-8') . '"></script>';
+                $includes[] = '<link rel="modulepreload" href="' . htmlspecialchars($this->buildPublicResourceUrl($manifestEntry['file']), ENT_QUOTES, 'UTF-8') . '">';
             }
             if (isset($manifestEntry['imports'])) {
                 $this->recurseImportedChunkFiles($includes, $manifestJson, $manifestEntry['imports']);


### PR DESCRIPTION
The "modulepreload" keyword is for the rel attribute of the link element. Previously it was added to a script element.

- https://vitejs.dev/guide/backend-integration.html
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload