### PR TITLE
fix: modulepreload tag

### DIFF
--- a/Classes/AssetIncludesBuilder.php
+++ b/Classes/AssetIncludesBuilder.php
@@ -155,7 +155,7 @@ class AssetIncludesBuilder
         foreach ($imports as $import) {
             $manifestEntry = $manifestJson[$import];
             if (isset($manifestEntry['file'])) {
-                $includes[] = '<script type="modulepreload" src="' . htmlspecialchars($this->buildPublicResourceUrl($manifestEntry['file']), ENT_QUOTES, 'UTF-8') . '"></script>';
+                $includes[] = '<link rel="modulepreload" href="' . htmlspecialchars($this->buildPublicResourceUrl($manifestEntry['file']), ENT_QUOTES, 'UTF-8') . '">';
             }
             if (isset($manifestEntry['imports'])) {
                 $this->recurseImportedChunkFiles($includes, $manifestJson, $manifestEntry['imports']);

--- a/Tests/Functional/AssetIncludesBuilderFunctionalTest.php
+++ b/Tests/Functional/AssetIncludesBuilderFunctionalTest.php
@@ -49,7 +49,7 @@ class AssetIncludesBuilderFunctionalTest extends FunctionalTestCase
             '<link rel="stylesheet" href="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/main.b82dbe22.css">' . PHP_EOL .
             '<link rel="stylesheet" href="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.a834bfc3.css">' . PHP_EOL .
             '<script type="module" src="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/main.4889e940.js"></script>' . PHP_EOL .
-            '<script type="modulepreload" src="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.83069a53.js"></script>'
+            '<link rel="modulepreload" href="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.83069a53.js">'
             , $html, 'should create correct includes for main entry');
 
         $file = $builder->productionUrl('main.js');
@@ -59,7 +59,7 @@ class AssetIncludesBuilderFunctionalTest extends FunctionalTestCase
         $this->assertEquals(
             '<link rel="stylesheet" href="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.a834bfc3.css">' . PHP_EOL .
             '<script type="module" src="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/foo.869aea0d.js"></script>' . PHP_EOL .
-            '<script type="modulepreload" src="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.83069a53.js"></script>'
+            '<link rel="modulepreload" href="http://localhost/_Resources/Testing/Static/Packages/Networkteam.Neos.Vite/Dist/assets/shared.83069a53.js">'
             , $html, 'should create correct includes for other entries');
 
         $file = $builder->productionUrl('views/foo.js');


### PR DESCRIPTION
New PR, sorry! Had to change the branch name to get the workflows to run. That closed #6 by mistake.

---

The "modulepreload" keyword is for the rel attribute of the link element. Previously it was added to a script element.

- https://vitejs.dev/guide/backend-integration.html
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload