### PR TITLE
fix: workflow deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   push:
-    branches: [main, '[0-9]+.[0-9]']
   pull_request:
     branches: [main, '[0-9]+.[0-9]']
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
     - name: Checkout Neos base distribution
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: neos/neos-base-distribution
         ref: ${{ matrix.neos-versions }}
         path: ${{ env.NEOS_FOLDER }}
 
     - name: Checkout package
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ${{ env.PACKAGE_FOLDER}}/${{ env.PACKAGE_NAME }}
 
@@ -48,9 +48,9 @@ jobs:
 
     - name: Get Composer cache directory
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-php${{ matrix.php-versions }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Get Composer cache directory
       id: composer-cache
-      run: echo "dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache composer dependencies
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
I've updated the test workflow to resolve the deprecations warnings.

As I wasn't able to have the workflow run in any of my feature branches, I've also removed the branch constraint. If you think there should be a restriction, we could obviously add one back.